### PR TITLE
Promote to prod environment

### DIFF
--- a/components/go-jbgkxppq/overlays/prod/deployment-patch.yaml
+++ b/components/go-jbgkxppq/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-tssc/task-runner:1.7
+      - image: nexus-docker-nexus.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-jbgkxppq:github-6d3e73fbdfa93a5c68451d8e17aeda1b1672de20
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: nexus-docker-nexus.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-jbgkxppq:github-6d3e73fbdfa93a5c68451d8e17aeda1b1672de20